### PR TITLE
Add aliases to avoid a crash.

### DIFF
--- a/animals.lua
+++ b/animals.lua
@@ -163,3 +163,8 @@ local gobdog_template = {
 -------------------------
 goblins.generate(gobdog_types,gobdog_template)
 
+mobs:alias_mob("goblins:goblins_goblin_dog", "goblins:goblin_gobdog")
+mobs:alias_mob("goblins:goblin_goblin_dog", "goblins:goblin_gobdog")
+
+mobs:alias_mob("goblins:goblins_goblin_dog_aggro", "goblins:goblin_gobdog_aggro")
+mobs:alias_mob("goblins:goblin_goblin_dog_aggro", "goblins:goblin_gobdog_aggro")


### PR DESCRIPTION
The `Gobdogs templated` commit (https://github.com/FreeLikeGNU/goblins/commit/b1bfc0717fca8ba7ecebc4401e851685e1ab3a12) unfortunately led to this crash on my server.
```
2020-05-04 10:14:44: ERROR[Server]: LuaEntity name "goblins:goblins_goblin_dog" not defined
2020-05-04 10:14:44: ERROR[Server]: LuaEntity name "goblins:goblins_goblin_dog_aggro" not defined
2020-05-04 10:14:44: ERROR[Server]: LuaEntity name "goblins:goblins_goblin_dog" not defined
2020-05-04 10:14:44: ERROR[Server]: LuaEntity name "goblins:goblins_goblin_dog" not defined
2020-05-04 10:14:45: ERROR[Server]: LuaEntity name "goblins:goblins_goblin_dog" not defined
2020-05-04 10:14:48: ERROR[Server]: LuaEntity name "goblins:goblins_goblin_dog" not defined
2020-05-04 10:14:48: ERROR[Server]: LuaEntity name "goblins:goblins_goblin_dog" not defined
2020-05-04 10:14:50: ACTION[Main]: Server: Shutting down
2020-05-04 10:14:50: ACTION[Server]: player leaves game. List of players: 
2020-05-04 10:14:51: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'goblins' in callback luaentity_Step(): ...ea/src/minetest/bin/../games/minetest_game/mods/mobs_redo/api.lua:1891: attempt to index local 'player' (a nil value)
2020-05-04 10:14:51: ERROR[Main]: stack traceback:
2020-05-04 10:14:51: ERROR[Main]:       ...ea/src/minetest/bin/../games/minetest_game/mods/mobs_redo/api.lua:1891: in function 'do_runaway_from'
2020-05-04 10:14:51: ERROR[Main]:       ...ea/src/minetest/bin/../games/minetest_game/mods/mobs_redo/api.lua:3377: in function <...ea/src/minetest/bin/../games/minetest_game/mods/mobs_redo/api.lua:3218>
```
The reason this happened is because before this commit goblins registered `"goblins:goblins_goblin_dog"` and `"goblins:goblins_goblin_dog_aggro"`.

https://github.com/FreeLikeGNU/goblins/blob/8bc760780962d7a06449327cbda259c90d5027ed/animals.lua#L77

Now they changed the `goblins` to `goblin`.

https://github.com/FreeLikeGNU/goblins/blob/b1bfc0717fca8ba7ecebc4401e851685e1ab3a12/behaviors.lua#L28

The easiest way to resolve this is to add some aliases.

Mobs_Redo probably shouldn't crash either...